### PR TITLE
Make it easier to interpolate velocities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Timestepping: the velocity and streamfunction fields are now represented as
+  `ClosedFilament`s. This can be convenient for interpolating their values
+  in-between discretisation points.
+
 ### Added
 
 - Timestepping: add optional `stretching_velocity` argument to `init`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ClosedFilament`s. This can be convenient for interpolating their values
   in-between discretisation points.
 
+- Change order of arguments in `Diagnostics.kinetic_energy*` functions, to make
+  it more consistent with other diagnostics functions.
+  This only applies to the variants which explicitly take a list of filaments and
+  streamfunction values.
+
 ### Added
 
 - Timestepping: add optional `stretching_velocity` argument to `init`.

--- a/src/BasicTypes/vector_of_vectors.jl
+++ b/src/BasicTypes/vector_of_vectors.jl
@@ -63,8 +63,7 @@ end
 Base.parent(x::VectorOfVectors) = x.u
 Base.length(x::VectorOfVectors) = length(x.u)
 Base.size(x::VectorOfVectors) = (length(x),)
-Base.similar(x::VectorOfVectors, ::Type{T}) where {T} =
-    VectorOfVectors(map(v -> similar(v, T), x.u))
+Base.similar(x::VectorOfVectors, ::Type{T}) where {T} = map(v -> similar(v, T), x) :: VectorOfVectors
 Base.similar(x::VectorOfVectors{T}) where {T} = similar(x, T)
 Base.fill!(x::VectorOfVectors, value) = (foreach(y -> fill!(y, value), x); x)
 Base.push!(x::VectorOfVectors, item) = push!(x.u, item)
@@ -93,6 +92,9 @@ end
 Base.resize!(vs::VectorOfVectors, n::Integer) = resize!(vs.u, n)
 Base.pop!(vs::VectorOfVectors) = pop!(vs.u)
 Base.popat!(vs::VectorOfVectors, i::Integer, args...) = popat!(vs.u, i, args...)
+
+# Make sure `map` returns a VectorOfVectors instead of a standard Vector.
+Base.map(f::F, vs::VectorOfVectors, args...) where {F} = VectorOfVectors(map(f, vs.u, args...))
 
 ## Broadcasting
 

--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -23,6 +23,17 @@ const VectorOfFilaments = AbstractVector{<:AbstractFilament}
 const SingleFilamentData = AbstractVector{<:Vec3}
 const SetOfFilamentsData = AbstractVector{<:SingleFilamentData}
 
+# Trait indicating whether we can interpolate a list of values, e.g. a vector of velocities
+# on filament discretisation points. A filament (or a filament-like object) can be
+# interpolated, while a regular vector cannot.
+struct IsInterpolable{B}
+    IsInterpolable(b::Bool) = new{b}()
+end
+
+isinterpolable(::Type{<:AbstractVector}) = IsInterpolable(false)
+isinterpolable(::Type{<:AbstractFilament}) = IsInterpolable(true)
+isinterpolable(u::AbstractVector) = isinterpolable(typeof(u))  # note: this also applies to filaments (since AbstractFilament <: AbstractVector)
+
 include("energy.jl")
 include("helicity.jl")
 include("filament_length.jl")

--- a/src/Diagnostics/energy.jl
+++ b/src/Diagnostics/energy.jl
@@ -77,20 +77,19 @@ in non-periodic domains.
 """
 function kinetic_energy_from_streamfunction end
 
-function kinetic_energy_from_streamfunction(ψs::AbstractVector, args...; quad = nothing)
-    _kinetic_energy_from_streamfunction(quad, ψs, args...)
-end
-
 # Case of a set of filaments
-function _kinetic_energy_from_streamfunction(
-        quad, ψs::SetOfFilamentsData, fs::VectorOfFilaments, Γ, args...,
-    )
-    T = float(typeof(Γ))
+function kinetic_energy_from_streamfunction(ψs::SetOfFilamentsData, fs::VectorOfFilaments, args...; kws...)
+    T = number_type(ψs)
     E = zero(T)
-    for i ∈ eachindex(fs, ψs)
-        E += _kinetic_energy_from_streamfunction(quad, ψs[i], fs[i], Γ, args...)
+    for i ∈ eachindex(ψs, fs)
+        E += kinetic_energy_from_streamfunction(ψs[i], fs[i], args...; kws...)
     end
     E
+end
+
+# Case of a single filament
+function kinetic_energy_from_streamfunction(ψs::SingleFilamentData, fs::AbstractFilament, args...; quad = nothing)
+    _kinetic_energy_from_streamfunction(quad, ψs, fs, args...)
 end
 
 function _domain_volume(Ls)
@@ -102,7 +101,6 @@ function _domain_volume(Ls)
     end
 end
 
-# Case of a single filament
 # 1. No quadratures (cheaper)
 function _kinetic_energy_from_streamfunction(::Nothing, ψf, f, Γ, Ls = (∞, ∞, ∞))
     prefactor = Γ / (2 * _domain_volume(Ls))
@@ -251,18 +249,19 @@ instead.
 """
 function kinetic_energy_nonperiodic end
 
-function kinetic_energy_nonperiodic(vs::AbstractVector, args...; quad = nothing)
-    _kinetic_energy_nonperiodic(quad, vs, args...)
-end
-
-function _kinetic_energy_nonperiodic(
-        quad, vs::SetOfFilamentsData, fs::VectorOfFilaments, Γ::AbstractFloat,
-    )
-    E = zero(typeof(Γ))
+# Case of a set of filaments
+function kinetic_energy_nonperiodic(vs::SetOfFilamentsData, fs::VectorOfFilaments, args...; kws...)
+    T = number_type(vs)
+    E = zero(T)
     for i ∈ eachindex(vs, fs)
-        E += _kinetic_energy_nonperiodic(quad, vs[i], fs[i], Γ)
+        E += kinetic_energy_nonperiodic(vs[i], fs[i], args...; kws...)
     end
     E
+end
+
+# Case of a single filament
+function kinetic_energy_nonperiodic(vs::SingleFilamentData, fs::AbstractFilament, args...; quad = nothing)
+    _kinetic_energy_nonperiodic(quad, vs, fs, args...)
 end
 
 # Case without quadratures

--- a/src/Diagnostics/energy.jl
+++ b/src/Diagnostics/energy.jl
@@ -157,8 +157,7 @@ function _kinetic_energy_from_streamfunction(::IsInterpolable{false}, quad, ψf,
             local data = @alloc(V, Np + 2M)
             PaddedVector{M}(data)
         end
-        # Note: we interpolate the streamfunction vector ψ⃗, which we then integrate along
-        # filaments.
+        # We interpolate the streamfunction vector ψ⃗.
         coefs = Filaments.init_coefficients(method, cs, cderiv)
         copyto!(cs, ψf)
         Filaments.compute_coefficients!(coefs, ts)

--- a/src/Diagnostics/helicity.jl
+++ b/src/Diagnostics/helicity.jl
@@ -91,23 +91,23 @@ function _helicity(::IsInterpolable{false}, quad, f::AbstractFilament, vs::Singl
     buf = Bumper.default_buffer()
 
     @no_escape buf begin
-        data = @alloc(T, Np + 2M)
+        V = eltype(vs)
+        data = @alloc(V, Np + 2M)
         cs = PaddedVector{M}(data)
         nderiv = Filaments.required_derivatives(method)
         cderiv = ntuple(Val(nderiv)) do _
-            local data = @alloc(T, Np + 2M)
+            local data = @alloc(V, Np + 2M)
             PaddedVector{M}(data)
         end
-        # Note: we interpolate the tangent component of the velocity (i.e. v⃗ ⋅ s⃗′),
-        # which we then integrate along filaments.
+        # We interpolate the the velocity vector v⃗.
         coefs = Filaments.init_coefficients(method, cs, cderiv)
-        for i ∈ eachindex(cs, f, vs)
-            @inbounds cs[i] = vs[i] ⋅ f[i, Derivative(1)]
-        end
+        copyto!(cs, vs)
         Filaments.compute_coefficients!(coefs, ts)
         for i ∈ eachindex(segments(f))
             H += integrate(f, i, quad) do f, i, ζ
-                Filaments.evaluate(coefs, ts, i, ζ)
+                v⃗ = Filaments.evaluate(coefs, ts, i, ζ)
+                s⃗′ = f(i, ζ, Derivative(1))
+                v⃗ ⋅ s⃗′
             end :: T
         end
     end

--- a/src/Diagnostics/helicity.jl
+++ b/src/Diagnostics/helicity.jl
@@ -60,6 +60,24 @@ end
 
 # Case with quadratures (requires interpolating the velocity along filaments)
 function _helicity(quad, f::AbstractFilament, vs::SingleFilamentData, Γ::Real)
+    _helicity(isinterpolable(vs), quad, f, vs, Γ)
+end
+
+function _helicity(::IsInterpolable{true}, quad, f::AbstractFilament, vs::SingleFilamentData, Γ::Real)
+    T = number_type(f)
+    @assert T <: AbstractFloat
+    H = zero(T)
+    for i ∈ eachindex(segments(f))
+        H += integrate(f, i, quad) do f, i, ζ
+            v⃗ = vs(i, ζ)
+            s⃗′ = f(i, ζ, Derivative(1))
+            v⃗ ⋅ s⃗′
+        end :: T
+    end
+    T(Γ) * H
+end
+
+function _helicity(::IsInterpolable{false}, quad, f::AbstractFilament, vs::SingleFilamentData, Γ::Real)
     T = number_type(f)
     @assert T <: AbstractFloat
     H = zero(T)

--- a/src/Filaments/Filaments.jl
+++ b/src/Filaments/Filaments.jl
@@ -166,8 +166,8 @@ nderivatives(f::AbstractFilament) = nderivatives(coefficients(f))
 Base.IndexStyle(::Type{<:AbstractFilament}) = IndexLinear()
 
 # This is needed since eltype(f) == Vec3{T}
-Base.similar(f::AbstractFilament, ::Type{Vec3{T}}, dims::Dims{1}) where {T} =
-    similar(f, T, dims)
+Base.similar(f::AbstractFilament, ::Type{Vec3{T}}, dims::Dims{1}; kws...) where {T} =
+    similar(f, T, dims; kws...)
 
 function Base.copyto!(v::F, u::F) where {F <: AbstractFilament}
     map(copyto!, allvectors(v), allvectors(u))

--- a/src/Filaments/Filaments.jl
+++ b/src/Filaments/Filaments.jl
@@ -166,8 +166,13 @@ nderivatives(f::AbstractFilament) = nderivatives(coefficients(f))
 Base.IndexStyle(::Type{<:AbstractFilament}) = IndexLinear()
 
 # This is needed since eltype(f) == Vec3{T}
-Base.similar(f::AbstractFilament, ::Type{Vec3{T}}, dims::Dims{1}; kws...) where {T} =
-    similar(f, T, dims; kws...)
+Base.similar(f::AbstractFilament, ::Type{Vec3{T}}, dims::Dims{1}) where {T} = similar(f, T, dims)
+
+# Like `similar` but accepts custom kwargs (offset, nderivs, ...).
+similar_filament(f::AbstractFilament, dims::Dims{1} = size(f); kws...) =
+    similar_filament(f, number_type(f), dims; kws...)
+similar_filament(f::AbstractFilament, ::Type{T}; kws...) where {T} =
+    similar_filament(f, T, size(f); kws...)
 
 function Base.copyto!(v::F, u::F) where {F <: AbstractFilament}
     map(copyto!, allvectors(v), allvectors(u))

--- a/src/Filaments/closed_filament.jl
+++ b/src/Filaments/closed_filament.jl
@@ -224,11 +224,14 @@ end
 
 allvectors(f::ClosedFilament) = (f.ts, f.Xs, allvectors(f.coefs)...)
 
-function Base.similar(f::ClosedFilament, ::Type{T}, dims::Dims{1}) where {T <: Number}
+function Base.similar(
+        f::ClosedFilament, ::Type{T}, dims::Dims{1};
+        offset = f.Xoffset,
+        method = discretisation_method(f),
+        nderivs::Val = Val(nderivatives(f)),
+    ) where {T <: Number}
     Xs = similar(nodes(f), Vec3{T}, dims)
-    method = discretisation_method(f)
-    nderivs = Val(nderivatives(f))
-    ClosedFilament(f.parametrisation, Xs, method; offset = f.Xoffset, nderivs)
+    ClosedFilament(f.parametrisation, Xs, method; offset, nderivs)
 end
 
 function update_coefficients!(f::ClosedFilament; knots = nothing)

--- a/src/Filaments/closed_filament.jl
+++ b/src/Filaments/closed_filament.jl
@@ -224,7 +224,12 @@ end
 
 allvectors(f::ClosedFilament) = (f.ts, f.Xs, allvectors(f.coefs)...)
 
-function Base.similar(
+function Base.similar(f::ClosedFilament, ::Type{T}, dims::Dims{1}) where {T <: Number}
+    similar_filament(f, T, dims)
+end
+
+# Like `similar` but accepts custom kwargs (offset, nderivs, ...).
+function similar_filament(
         f::ClosedFilament, ::Type{T}, dims::Dims{1};
         offset = f.Xoffset,
         method = discretisation_method(f),

--- a/src/Timestepping/diagnostics.jl
+++ b/src/Timestepping/diagnostics.jl
@@ -15,7 +15,7 @@ function Diagnostics.kinetic_energy_from_streamfunction(iter::VortexFilamentSolv
     (; ψs, fs, external_forcing, t,) = iter
     Ls = BiotSavart.periods(iter.prob.p)
     Γ = BiotSavart.circulation(iter.prob.p)
-    E = Diagnostics.kinetic_energy_from_streamfunction(ψs, fs, Γ, Ls; kws...)
+    E = Diagnostics.kinetic_energy_from_streamfunction(fs, ψs, Γ, Ls; kws...)
     # Add kinetic energy of external velocity field, if available.
     # Note that we only do this if we also included the streamfunction, since otherwise
     # we don't have enough information to estimate the total kinetic energy.
@@ -48,7 +48,7 @@ function Diagnostics.kinetic_energy_nonperiodic(iter::VortexFilamentSolver; kws.
     BiotSavart.domain_is_periodic(iter.prob.p) &&
         @warn(lazy"`kinetic_energy_nonperiodic` should only be called when working with non-periodic domains (got Ls = $Ls)")
     Γ = BiotSavart.circulation(iter.prob.p)
-    Diagnostics.kinetic_energy_nonperiodic(vs, fs, Γ; kws...)
+    Diagnostics.kinetic_energy_nonperiodic(fs, vs, Γ; kws...)
 end
 
 # Note: filament_length is actually defined in the Filaments module, but we document its

--- a/test/hdf5.jl
+++ b/test/hdf5.jl
@@ -163,7 +163,7 @@ function test_hdf5()
     # Try writing data which is *not* backed by a PaddedVector.
     # When refinement is enabled, values on the last segment should be obtained by
     # interpolation using the last and first data points, since there's no padding.
-    ψt_vec = VectorOfVectors(map(ψ -> Vector{Float64}(undef, length(ψ)), ψs)) :: AbstractVector{<:Vector}
+    ψt_vec = map(ψ -> Vector{Float64}(undef, length(ψ)), ψs) :: AbstractVector{<:Vector}
     tangent_streamfunction!(ψt_vec, fs, ψs)
     @test ψt == ψt_vec
 

--- a/test/infinite_lines.jl
+++ b/test/infinite_lines.jl
@@ -200,7 +200,7 @@ function test_infinite_lines(method)
         end
     end
 
-    E = Diagnostics.kinetic_energy(ψs, filaments, params.Γ, params.Ls)
+    E = Diagnostics.kinetic_energy(filaments, ψs, params.Γ, params.Ls)
 
     @testset "Energy spectrum" begin
         ks, Ek = Diagnostics.energy_spectrum(cache)

--- a/test/kelvin_waves.jl
+++ b/test/kelvin_waves.jl
@@ -123,7 +123,7 @@ function test_kelvin_waves(
         # local quad = nothing
         # local quad = GaussLegendre(4)
         local quad = prob.p.common.quad_near_singularity
-        E = Diagnostics.kinetic_energy_from_streamfunction(ψs, fs, Γ, Ls; quad)
+        E = Diagnostics.kinetic_energy_from_streamfunction(fs, ψs, Γ, Ls; quad)
         # if nstep % 10 == 0
         #     @show nstep, t/T, E
         # end

--- a/test/padded_arrays.jl
+++ b/test/padded_arrays.jl
@@ -143,13 +143,15 @@ using Test
         data = collect(1:20)
         v = @inferred PaddedArray{2}(data)
         w = similar(v)
-        fill!(w, 0)
+        fill!(parent(w), 0)
         # 1. Copy only non-ghost cells.
         @views w[:] .= v[:]  # this doesn't include ghost cells
+        @test parent(w) != parent(v)
         @test w != v  # arrays are different because ghost cells were not copied!
         @test !isapprox(w, v)
         # 2. Copy including ghost cells.
         copyto!(w, v)  # this includes ghost cells
+        @test parent(w) == parent(v)
         @test w == v   # arrays are now equal
         @test isapprox(w, v)
     end

--- a/test/ring.jl
+++ b/test/ring.jl
@@ -116,8 +116,8 @@ function test_vortex_ring_nonperiodic(ring; quad = GaussLegendre(4))
     @testset "Normalised energy" begin
         Ls = BiotSavart.periods(params)  # all Infinity() in this case
         E_expected = (Γ^2 * R/2) * (log(8R / a) - (Δ + 1))  # energy per unit density
-        E_estimated = Diagnostics.kinetic_energy_from_streamfunction(ψs, f, Γ, Ls)  # energy per unit density
-        # E_alt = Diagnostics.kinetic_energy_nonperiodic(vs, f, Γ)
+        E_estimated = Diagnostics.kinetic_energy_from_streamfunction(f, ψs, Γ, Ls)  # energy per unit density
+        # E_alt = Diagnostics.kinetic_energy_nonperiodic(f, vs, Γ)
         # @show E_expected E_estimated E_alt
         # @show f.parametrisation (E_expected - E_estimated) / E_expected
         rtol = nquad == 1 ? 0.02 : 1e-4

--- a/test/ring_perturbed.jl
+++ b/test/ring_perturbed.jl
@@ -74,7 +74,19 @@ function test_perturbed_vortex_ring()
             yield()
         end
         local (; fs, ψs, vs,) = iter
+        local (; Γ, Ls,) = iter.prob.p
         if nstep % 100 == 0  # don't output very often; just for tests
+            # Compare with diagnostics implementations which don't take an interpolable
+            # field as input, so they must build the interpolation themselves.
+            vs_p = map(nodes, vs)  # velocity values on nodes (without interpolation data)
+            ψs_p = map(nodes, ψs)
+            E_alt = Diagnostics.kinetic_energy_from_streamfunction(ψs_p, fs, Γ, Ls; quad)
+            H_alt = Diagnostics.helicity(fs, vs_p, Γ; quad)
+            dLdt_alt = Diagnostics.stretching_rate(fs, vs_p; quad)
+            @test dLdt == dLdt_alt
+            @test E == E_alt
+            @test abs(H) < 1e-5  # in theory it's equal to zero
+            @test H ≈ H_alt
             let fname = "ring_perturbed_$nstep.vtkhdf"
                 write_vtkhdf(fname, fs; refinement = 4, periods = Ls) do io
                     io["velocity"] = vs

--- a/test/ring_perturbed.jl
+++ b/test/ring_perturbed.jl
@@ -80,7 +80,7 @@ function test_perturbed_vortex_ring()
             # field as input, so they must build the interpolation themselves.
             vs_p = map(nodes, vs)  # velocity values on nodes (without interpolation data)
             ψs_p = map(nodes, ψs)
-            E_alt = Diagnostics.kinetic_energy_from_streamfunction(ψs_p, fs, Γ, Ls; quad)
+            E_alt = Diagnostics.kinetic_energy_from_streamfunction(fs, ψs_p, Γ, Ls; quad)
             H_alt = Diagnostics.helicity(fs, vs_p, Γ; quad)
             dLdt_alt = Diagnostics.stretching_rate(fs, vs_p; quad)
             @test dLdt == dLdt_alt

--- a/test/ring_perturbed.jl
+++ b/test/ring_perturbed.jl
@@ -9,7 +9,7 @@ using VortexPasta.Diagnostics: Diagnostics
 using UnicodePlots: lineplot
 using LinearAlgebra: ⋅
 
-@testset "Perturbed vortex ring" begin
+function test_perturbed_vortex_ring()
     R = π / 4
     N = 48
     r_perturb(t) = 0.10 * sinpi(6t)  # mode m = 3
@@ -45,10 +45,10 @@ using LinearAlgebra: ⋅
         display(fig)
     end
 
-    times::Vector{Float64} = Float64[]
-    energy_time::Vector{Float64} = Float64[]
-    helicity_time::Vector{Float64} = Float64[]
-    tsf::TimeSeriesFile = TimeSeriesFile()
+    times = Float64[]
+    energy_time = Float64[]
+    helicity_time = Float64[]
+    tsf = TimeSeriesFile()
 
     function callback(iter)
         (; nstep, t,) = iter.time
@@ -74,7 +74,7 @@ using LinearAlgebra: ⋅
                 write_vtkhdf(fname, fs; refinement = 4, periods = Ls) do io
                     io["velocity"] = vs
                     io["streamfunction"] = ψs
-                    ψt = similar(ψs, Float64)
+                    ψt = map(f -> similar(nodes(f), Float64), fs)
                     for (f, ψs, ψt) ∈ zip(fs, ψs, ψt)
                         for i ∈ eachindex(f, ψs, ψt)
                             ψt[i] = f[i, UnitTangent()] ⋅ ψs[i]
@@ -135,4 +135,10 @@ using LinearAlgebra: ⋅
         )
         println(plt)
     end
+
+    nothing
+end
+
+@testset "Perturbed vortex ring" begin
+    test_perturbed_vortex_ring()
 end

--- a/test/ring_perturbed.jl
+++ b/test/ring_perturbed.jl
@@ -117,8 +117,6 @@ function test_perturbed_vortex_ring()
     @time solve!(iter)
     save("ring_perturbed.vtkhdf.series", tsf)
 
-
-
     @test iter.dt == dt  # dt was kept to the initial value (because AdaptBasedOnVelocity criterion gives larger dt)
 
     # Check that velocity and streamfunction can be interpolated, and that the interpolated


### PR DESCRIPTION
In timestepping, we now treat the velocity and streamfunction on filaments as filament-like objects, meaning that they can be easily interpolated in-between discretisation points.