### PR TITLE
Make things work with AMDGPU + minor GPU-related changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add support for AMD GPUs via [AMDGPU.jl](https://github.com/JuliaGPU/AMDGPU.jl).
+  This requires using the `NonuniformFFTsBackend` for computing long-range
+  interactions, and setting the device to `ROCBackend()`.
+
 ## [0.24.5] - 2024-09-20
 
 ### Added

--- a/src/BiotSavart/BiotSavart.jl
+++ b/src/BiotSavart/BiotSavart.jl
@@ -469,7 +469,7 @@ function _compute_on_nodes!(
                 @assert device_lr isa PseudoGPU || typeof(pointdata) !== typeof(pointdata_d)
                 @timeit to_d "Copy point charges (host → device)" begin
                     copy!(pointdata_d, pointdata)  # H2D copy
-                    KA.synchronize(device_lr)
+                    KA.synchronize(device_lr)   # TODO: is this needed?
                 end
                 @timeit to_d "Vorticity to Fourier" begin
                     compute_vorticity_fourier!(cache.longrange)  # reads pointdata_d (points and charges)

--- a/src/BiotSavart/longrange/finufft.jl
+++ b/src/BiotSavart/longrange/finufft.jl
@@ -303,6 +303,8 @@ function transform_to_fourier!(c::FINUFFTCache)
     finufft_unpin_threads(backend_lr) do  # disable ThreadPinning in the CPU version (see VortexPastaThreadPinningExt)
         @timeit to_d "$name_to setpts" begin
             _finufft_setpts_func!(backend_lr)(plan_type1, points_data...)
+            # For now we need synchronisation since generally CuFINUFFT code and Julia code
+            # run on separate CUDA streams.
             _finufft_sync(backend_lr)  # similar to KA.synchronize, but applies to the CUDA stream attached to cuFINUFFT (irrelevant for CPU case)
         end
         resize!(charge_data, 3 * Np)

--- a/src/BiotSavart/longrange/ka_utils.jl
+++ b/src/BiotSavart/longrange/ka_utils.jl
@@ -26,9 +26,9 @@ function ka_default_workgroupsize(::KA.CPU, dims::Dims)
 end
 
 function ka_default_workgroupsize(::KA.GPU, dims::Dims)
-    # On the GPU, we divide the work across the first dimension and try to use 256 GPU
+    # On the GPU, we divide the work across the first dimension and try to use 512 GPU
     # threads per workgroup.
-    wgsize_wanted = 256
+    wgsize_wanted = 512
     x = map(one, dims)  # = (1, 1, 1) in 3D
     Base.setindex(x, min(dims[1], wgsize_wanted), 1)  # usually (wgsize_wanted, 1, 1)
 end

--- a/src/BiotSavart/longrange/ka_utils.jl
+++ b/src/BiotSavart/longrange/ka_utils.jl
@@ -68,7 +68,7 @@ end
 struct PseudoGPU <: KA.GPU end
 
 KA.isgpu(::PseudoGPU) = false  # needed to be considered as a CPU backend by KA
-KA.allocate(::PseudoGPU, args...) = KA.allocate(KA.CPU(), args...)
+KA.allocate(::PseudoGPU, ::Type{T}, dims::Dims) where {T} = KA.allocate(KA.CPU(), T, dims)
 KA.synchronize(::PseudoGPU) = nothing
 KA.copyto!(::PseudoGPU, u, v) = copyto!(u, v)
 Adapt.adapt(::PseudoGPU, u::Array) = copy(u)  # simulate host → device copy (making sure arrays are not aliased)

--- a/src/BiotSavart/longrange/longrange.jl
+++ b/src/BiotSavart/longrange/longrange.jl
@@ -473,8 +473,12 @@ function _set_interpolation_points!(device::KA.GPU, points::NTuple{N}, fs) where
     @no_escape buf begin
         Xs = map(x -> @alloc(eltype(x), length(x)), points)
         _set_interpolation_points!(KA.CPU(), Xs, fs)  # calls CPU implementation
-        for i ∈ eachindex(points, Xs)
-            KA.copyto!(device, points[i], Xs[i])  # host-to-device copy
+        GC.@preserve Xs begin
+            for i ∈ eachindex(points, Xs)
+                # "Convert" Bumper array to standard Array to make things work with AMDGPU.
+                src = unsafe_wrap(Array, pointer(Xs[i]), size(Xs[i]))
+                KA.copyto!(device, points[i], src)  # host-to-device copy
+            end
         end
     end
     points
@@ -507,8 +511,12 @@ function _add_long_range_output!(device::KA.GPU, vs, charges::StructVector{V}) w
     @no_escape buf begin
         qs = StructArrays.components(charges)  # (qx, qy, qz)
         vtmp = map(q -> @alloc(eltype(q), length(q)), qs)  # temporary CPU arrays
-        for i ∈ eachindex(vtmp, qs)
-            KA.copyto!(device, vtmp[i], qs[i])  # device-to-host copy
+        GC.@preserve vtmp begin
+            for i ∈ eachindex(vtmp, qs)
+                # "Convert" Bumper array to standard Array to make things work with AMDGPU.
+                dst = unsafe_wrap(Array, pointer(vtmp[i]), size(vtmp[i]))
+                KA.copyto!(device, dst, qs[i])  # device-to-host copy
+            end
         end
         vtmp_struct = StructVector{V}(vtmp)  # vtmp as a StructVector
         _add_long_range_output!(KA.CPU(), vs, vtmp_struct)

--- a/src/BiotSavart/longrange/nonuniformffts.jl
+++ b/src/BiotSavart/longrange/nonuniformffts.jl
@@ -14,7 +14,7 @@ non-uniform data, meaning that we can use real-to-complex FFTs to accelerate com
 
 Transforms can be performed either on the CPU (parallelised with threads, default) or on a
 single GPU (in principle any kind of GPU should work, but only CUDA has been tested).
-This must be set via the `device` argiment (see below).
+This must be set via the `device` argument (see below).
 
 # Optional arguments
 

--- a/src/BiotSavart/longrange/nonuniformffts.jl
+++ b/src/BiotSavart/longrange/nonuniformffts.jl
@@ -35,7 +35,7 @@ For example, to use a CUDA device:
     using CUDA
     backend_long = NonuniformFFTsBackend(CUDABackend(); kwargs...)
 
-On AMD GPUs, the following should hopefully work (not tested):
+On AMD GPUs the following should work:
 
     using AMDGPU
     backend_long = NonuniformFFTsBackend(ROCBackend(); kwargs...)

--- a/src/Diagnostics/spectra.jl
+++ b/src/Diagnostics/spectra.jl
@@ -183,7 +183,6 @@ function energy_spectrum!(
         Base.mapreducedim!(identity, +, Ek_d, Ek_groups)  # sum values from all workgroups onto Ek_d
 
         if backend isa KA.GPU
-            KA.synchronize(backend)
             KA.unsafe_free!(Ek_groups)  # manually free GPU memory
         end
     end


### PR DESCRIPTION
Making things work with AMDGPU only required some very minor changes:

- host-device copies can't be performed using arrays allocated via Bumper, so we "convert" these onto standard `Array`s using `unsafe_wrap`;
- asynchronous execution of FFTs, for simultaneous computation of long-range (on GPU) and short-range (on CPU) components, fails on current AMDGPU.jl version (v1.0.4). This is fixed in the current AMDGPU.jl master.