### PR TITLE
Store both self-induced and total velocity in Timestepping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- **Breaking**: When a normal fluid is applied, the `vs` field of
+  a `VortexFilamentSolver` (usually `iter.vs`) now represents the self-induced
+  vortex velocity, while the `vL` field is the actual filament velocity
+  including the contribution from mutual friction.
+
 ### Added
+
+- Store self-induced velocity ($v_s$) in addition to the actual filament
+  velocity ($v_L$) in `Timestepping.VortexFilamentSolver`.
 
 - Allow saving state of `FourierBandVectorField` to HDF5 file and loading it back.
   This is useful in particular for restarts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   vortex velocity, while the `vL` field is the actual filament velocity
   including the contribution from mutual friction.
 
+- Short-range parallelisation using threads: use finer-grained parallelisation
+  at the level of the nodes of each filament. This is fine since the cost of
+  computing all short-range interactions on a filament node is relatively large,
+  so that the overhead of threading is relatively very small. Moreover, it's
+  much faster when we have a small number of filaments (which, counterintuitively,
+  can be relevant for turbulent cases). Also, we now avoid using `@threads :static`.
+
 ### Added
 
 - Store self-induced velocity ($v_s$) in addition to the actual filament

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.25.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"
@@ -43,6 +44,7 @@ VortexPastaThreadPinningExt = ["ThreadPinning"]
 
 [compat]
 AbstractFFTs = "1.3"
+Accessors = "0.1.39"
 Adapt = "4.0.4"
 Bumper = "0.4, 0.5, 0.6, 0.7"
 CUDA = "5.4.3"

--- a/src/BiotSavart/pointdata.jl
+++ b/src/BiotSavart/pointdata.jl
@@ -100,7 +100,7 @@ function add_point_charges!(data::PointData, fs::AbstractVector{<:AbstractFilame
     Ncharges = _count_charges(quad, fs)
     set_num_points!(data, Ncharges)
     inds = ChunkSplitters.chunks(eachindex(fs); n = Threads.nthreads())
-    Threads.@threads :static for subinds ∈ inds
+    Threads.@threads for subinds ∈ inds
         subinds === nothing && continue  # subinds can be nothing; see iterate(c::Chunk) in ChunkSplitters
         prev_indices = firstindex(fs):(first(subinds) - 1)  # filament indices given to all previous chunks
         n = _count_charges(quad, view(fs, prev_indices))    # we will start writing at index n + 1

--- a/src/BiotSavart/shortrange/shortrange.jl
+++ b/src/BiotSavart/shortrange/shortrange.jl
@@ -174,7 +174,7 @@ function remove_long_range_self_interaction!(
         fs::VectorOfFilaments,
         args...,
     )
-    Threads.@threads :static for i ∈ eachindex(vs, fs)
+    Threads.@threads for i ∈ eachindex(vs, fs)
         @inbounds v, f = vs[i], fs[i]
         remove_long_range_self_interaction!(v, f, args...)
     end
@@ -187,13 +187,8 @@ function add_short_range_fields!(
         fs::VectorOfFilaments;
         kws...,
     ) where {Names, N, V <: AbstractVector{<:VectorOfVec}}
-    # We parallelise at the level of the list of filaments.
-    # This is good when there are many filaments.
-    # Moreover, the :static scheduling option makes sense when roughly all the filaments
-    # have the same number of points. If that's not the case, it may be worth it to either
-    # (1) reorder filaments such that every "chunk" has oroughly the same number of points,
-    # or (2) use :dynamic scheduling.
-    Threads.@threads :static for i ∈ eachindex(fs)
+    # We parallelise at the level of the list of filaments. This is good when there are many filaments.
+    Threads.@threads for i ∈ eachindex(fs)
         fields_i = map(us -> us[i], fields)  # velocity/streamfunction of i-th filament
         add_short_range_fields!(fields_i, cache, fs[i]; kws...)
     end

--- a/src/Forcing/Forcing.jl
+++ b/src/Forcing/Forcing.jl
@@ -48,10 +48,10 @@ In particular, the function could be a synthetic velocity field from the
 [`SyntheticFields`](@ref) module (see below for examples).
 
 This type of forcing defines an external velocity ``\bm{v}_{\text{f}}`` affecting vortex
-motion, so that the effective vortex velocity is
+motion, so that the actual vortex velocity ``\bm{v}_{\text{L}}`` is
 
 ```math
-\frac{\mathrm{d}\bm{s}}{\mathrm{d}t} = \bm{v}_{\text{s}} + \bm{v}_{\text{f}}.
+\frac{\mathrm{d}\bm{s}}{\mathrm{d}t} = \bm{v}_{\text{L}} = \bm{v}_{\text{s}} + \bm{v}_{\text{f}}.
 ```
 
 Here ``\bm{v}_{\text{s}}`` is the self-induced velocity obtained by applying Biot–Savart's law.

--- a/src/SyntheticFields/fourier.jl
+++ b/src/SyntheticFields/fourier.jl
@@ -21,7 +21,7 @@ For this one can call [`SyntheticFields.init_coefficients!`](@ref) after creatin
 After that, one can evaluate the field as described in [`SyntheticVectorField`](@ref).
 
 Moreover the state can be saved to an HDF5 file with
-[`SyntheticField.save_coefficients`](@ref) and loaded back with
+[`SyntheticFields.save_coefficients`](@ref) and loaded back with
 [`SyntheticFields.load_coefficients!`](@ref).
 
 # Positional arguments

--- a/src/Timestepping/Timestepping.jl
+++ b/src/Timestepping/Timestepping.jl
@@ -52,6 +52,7 @@ using ..Forcing: Forcing, AbstractForcing, NormalFluidForcing
 # See https://docs.sciml.ai/CommonSolve/stable/
 import CommonSolve: init, solve!, step!
 
+using Accessors: @delete  # allows to remove entry from (Named)Tuple
 using ForwardDiff: ForwardDiff
 using TimerOutputs: TimerOutputs, TimerOutput, @timeit, reset_timer!
 

--- a/src/Timestepping/Timestepping.jl
+++ b/src/Timestepping/Timestepping.jl
@@ -293,8 +293,8 @@ end
     quantities = getfield(iter, :quantities)
     if hasproperty(time, name)
         getproperty(time, name)
-    elseif hasproperty(quantities, name)
-        getproperty(quantities, name)
+    elseif haskey(quantities, name)
+        quantities[name]
     else
         getfield(iter, name)
     end

--- a/src/Timestepping/adaptivity.jl
+++ b/src/Timestepping/adaptivity.jl
@@ -175,7 +175,7 @@ maximum_displacement(crit::AdaptBasedOnVelocity) = crit.δ
 function estimate_timestep(crit::AdaptBasedOnVelocity, iter::AbstractSolver)
     (; dt_prev,) = iter  # dt_prev is the latest used timestep
     T = typeof(dt_prev)
-    v_max = maximum_vector_norm(iter.vs)
+    v_max = maximum_vector_norm(iter.quantities.vL)
     dt_estimate::T = crit.safety_factor * crit.δ / v_max
     # Avoid increasing the dt too abruptly compared to the previous timestep.
     # This seems to help reduce the number of rejected timesteps, in case the dt was reduced

--- a/src/Timestepping/diagnostics.jl
+++ b/src/Timestepping/diagnostics.jl
@@ -20,7 +20,7 @@ function Diagnostics.kinetic_energy_from_streamfunction(iter::VortexFilamentSolv
 end
 
 function Diagnostics.kinetic_energy_nonperiodic(iter::VortexFilamentSolver; kws...)
-    (; vs, fs,) = iter
+    (; vs, fs,) = iter  # note: here we want vs (self-induced velocity) and not vL
     Ls = BiotSavart.periods(iter.prob.p)
     BiotSavart.domain_is_periodic(iter.prob.p) &&
         @warn(lazy"`kinetic_energy_nonperiodic` should only be called when working with non-periodic domains (got Ls = $Ls)")
@@ -39,12 +39,12 @@ function Diagnostics.vortex_impulse(iter::VortexFilamentSolver; kws...)
 end
 
 function Diagnostics.helicity(iter::VortexFilamentSolver; kws...)
-    Diagnostics.helicity(iter.fs, iter.vs, iter.prob.p; kws...)
+    Diagnostics.helicity(iter.fs, iter.vL, iter.prob.p; kws...)
 end
 
 function Diagnostics.stretching_rate(iter::VortexFilamentSolver; kws...)
-    (; fs, vs,) = iter
-    Diagnostics.stretching_rate(fs, vs; kws...)
+    (; fs, vL,) = iter
+    Diagnostics.stretching_rate(fs, vL; kws...)
 end
 
 # This allows passing a VortexFilamentSolver to energy_spectrum / energy_spectrum!.

--- a/src/Timestepping/forcing.jl
+++ b/src/Timestepping/forcing.jl
@@ -72,7 +72,7 @@ function _apply_forcing!(vs_all, forcing::NormalFluidForcing, iter, fs, t, to)
                 tangents[i] = f[i, UnitTangent()]
             end
             Forcing.get_velocities!(forcing, vn, f)    # evaluate normal fluid velocities
-            Forcing.apply!(forcing, vs, vn, tangents)  # modify vs according to the given forcing
+            Forcing.apply!(forcing, vs, vs, vn, tangents)  # modify vs according to the given forcing
         end
     end
     nothing

--- a/src/Timestepping/forcing.jl
+++ b/src/Timestepping/forcing.jl
@@ -50,29 +50,40 @@ end
 
 function apply_forcing!(fields::NamedTuple, iter::VortexFilamentSolver, fs, time, to)
     if haskey(fields, :velocity)
+        # At this point, fields.velocity is expected to have the self-induced velocity vs.
+        # After applying a normal fluid forcing, fields.velocity will contain the actual
+        # vortex velocity vL. The self-induced velocity will be copied to iter.quantities.vs.
         _apply_forcing!(fields.velocity, iter.forcing, iter, fs, time, to)
     end
     fields
 end
 
-_apply_forcing!(vs_all, ::Nothing, args...) = nothing  # do nothing
+_apply_forcing!(vL, ::Nothing, args...) = nothing  # do nothing
 
-function _apply_forcing!(vs_all, forcing::NormalFluidForcing, iter, fs, t, to)
-    vn_all = iter.vn
-    tangents_all = iter.tangents
-    @assert eachindex(vn_all) == eachindex(tangents_all) == eachindex(vs_all) == eachindex(fs)
+function _apply_forcing!(vL_all, forcing::NormalFluidForcing, iter, fs, t, to)
+    # Note: inside a RK substep, quantities.{vs,vn,tangents} are used as temporary buffers
+    # (and in fact we don't really need vs).
+    (; quantities,) = iter
+    vs_all = quantities.vs  # self-induced velocities will be copied here
+    vn_all = quantities.vn  # normal fluid velocities will be computed here
+    tangents_all = quantities.tangents  # local tangents
+    @assert vs_all !== vL_all
+    @assert eachindex(vL_all) == eachindex(vn_all) == eachindex(tangents_all) == eachindex(vs_all) == eachindex(fs)
     @timeit to "Add forcing" begin
-        @inbounds Threads.@threads for n ∈ eachindex(fs, vs_all, vn_all, tangents_all)
+        @inbounds Threads.@threads for n ∈ eachindex(fs)
             f = fs[n]
             vs = vs_all[n]
+            vL = vL_all[n]
             vn = vn_all[n]
             tangents = tangents_all[n]
-            # Compute tangents (TODO: can we reuse them?)
+            # At input, vL contains the self-induced velocity vs.
+            # We copy vL -> vs before modifying vL with the actual vortex velocities.
             for i ∈ eachindex(f, tangents)
-                tangents[i] = f[i, UnitTangent()]
+                tangents[i] = f[i, UnitTangent()]  # TODO: can we reuse the tangents / computed elsewhere?
+                vs[i] = vL[i]
             end
             Forcing.get_velocities!(forcing, vn, f)    # evaluate normal fluid velocities
-            Forcing.apply!(forcing, vs, vs, vn, tangents)  # modify vs according to the given forcing
+            Forcing.apply!(forcing, vL, vn, tangents)  # compute vL according to the given forcing (vL = vs at input)
         end
     end
     nothing

--- a/src/Timestepping/timesteppers/timesteppers.jl
+++ b/src/Timestepping/timesteppers/timesteppers.jl
@@ -74,13 +74,13 @@ function Base.resize!(cache::TemporalSchemeCache, fs::VectorOfFilaments)
 end
 
 function update_velocities!(
-        vs::VectorOfVectors, rhs!::F, advect!::G, cache::TemporalSchemeCache, iter::AbstractSolver;
+        vL::VectorOfVectors, rhs!::F, advect!::G, cache::TemporalSchemeCache, iter::AbstractSolver;
         resize_cache = true, kws...,
     ) where {F <: Function, G <: Function}
     if resize_cache
         resize!(cache, iter.fs)  # in case the number of nodes (or filaments) has changed
     end
-    _update_velocities!(scheme(cache), vs, rhs!, advect!, cache, iter; kws...)
+    _update_velocities!(scheme(cache), vL, rhs!, advect!, cache, iter; kws...)
 end
 
 include("explicit/explicit.jl")


### PR DESCRIPTION
Also, when a normal fluid is applied, `iter.vs` is now the self-induced velocity, and `iter.vL` is the actual filament velocity including the influence of the normal fluid.