### PR TITLE
Diagnostics: use quadrature in ParamsBiotSavart when possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       POCL_WORK_GROUP_METHOD: cbs  # might help avoid crashes (https://github.com/pocl/pocl/issues/1971#issuecomment-3062532073)
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         experimental: [false]
         julia-version:

--- a/src/Diagnostics/energy.jl
+++ b/src/Diagnostics/energy.jl
@@ -5,9 +5,9 @@ using HCubature: HCubature
 export kinetic_energy_from_streamfunction, kinetic_energy_nonperiodic, kinetic_energy
 
 """
-    kinetic_energy(iter::VortexFilamentSolver; quad = nothing) -> Real
+    kinetic_energy(iter::VortexFilamentSolver; quad = iter.prob.p.quad) -> Real
+    kinetic_energy(fs, ψs, p::ParamsBiotSavart; quad = p.quad) -> Real
     kinetic_energy(fs, ψs, Γ::Real, [Ls]; quad = nothing) -> Real
-    kinetic_energy(fs, ψs, p::ParamsBiotSavart; quad = nothing) -> Real
 
 Compute kinetic energy of velocity field induced by a set of vortex filaments.
 
@@ -22,9 +22,9 @@ end
 # Periodic case
 
 @doc raw"""
-    kinetic_energy_from_streamfunction(iter::VortexFilamentSolver; quad = nothing)
+    kinetic_energy_from_streamfunction(iter::VortexFilamentSolver; quad = iter.prob.p.quad)
+    kinetic_energy_from_streamfunction(fs, ψs, p::ParamsBiotSavart; quad = p.quad)
     kinetic_energy_from_streamfunction(fs, ψs, Γ::Real, [Ls]; quad = nothing)
-    kinetic_energy_from_streamfunction(fs, ψs, p::ParamsBiotSavart; quad = nothing)
 
 Compute kinetic energy per unit mass (units ``L^2 T^{-2}``) from streamfunction values at
 filament nodes in a periodic domain.
@@ -85,10 +85,10 @@ function kinetic_energy_from_streamfunction end
 # Case of a set of filaments
 function kinetic_energy_from_streamfunction(
         fs::VectorOfFilaments, ψs::SetOfFilamentsData, args...;
-        quad = nothing, nthreads = Threads.nthreads()
+        nthreads = Threads.nthreads(), kwargs...,
     )
     maybe_parallelise_sum(fs, nthreads) do i, inds
-        kinetic_energy_from_streamfunction(fs[i], ψs[i], args...; quad, inds)
+        kinetic_energy_from_streamfunction(fs[i], ψs[i], args...; inds, kwargs...)
     end
 end
 
@@ -98,7 +98,7 @@ function kinetic_energy_from_streamfunction(f::AbstractFilament, ψs::SingleFila
 end
 
 function kinetic_energy_from_streamfunction(f::AbstractFilament, ψs::SingleFilamentData, p::ParamsBiotSavart; kws...)
-    kinetic_energy_from_streamfunction(f, ψs, p.Γ, p.Ls; kws...)
+    kinetic_energy_from_streamfunction(f, ψs, p.Γ, p.Ls; quad = p.quad, kws...)
 end
 
 # 1. No quadratures (cheaper)
@@ -200,9 +200,9 @@ end
 # 0 at infinity.
 
 @doc raw"""
-    kinetic_energy_nonperiodic(iter::VortexFilamentSolver; quad = nothing) -> Real
+    kinetic_energy_nonperiodic(iter::VortexFilamentSolver; quad = iter.prob.p.quad) -> Real
+    kinetic_energy_nonperiodic(fs, vs, p::ParamsBiotSavart; quad = p.quad) -> Real
     kinetic_energy_nonperiodic(fs, vs, Γ::Real; quad = nothing) -> Real
-    kinetic_energy_nonperiodic(fs, vs, p::ParamsBiotSavart; quad = nothing) -> Real
 
 Compute kinetic energy per unit density (units ``L^5 T^{-2}``) from velocity values at
 filament nodes in an open (non-periodic) domain.
@@ -273,7 +273,7 @@ function kinetic_energy_nonperiodic(fs::AbstractFilament, vs::SingleFilamentData
 end
 
 function kinetic_energy_nonperiodic(fs::AbstractFilament, vs::SingleFilamentData, p::ParamsBiotSavart; kws...)
-    kinetic_energy_nonperiodic(fs, vs, p.Γ; kws...)
+    kinetic_energy_nonperiodic(fs, vs, p.Γ; quad = p.quad, kws...)
 end
 
 # Case without quadratures

--- a/src/Diagnostics/energy_flux.jl
+++ b/src/Diagnostics/energy_flux.jl
@@ -3,8 +3,8 @@ export energy_flux, energy_transfer_matrix
 using Adapt: Adapt, adapt
 
 @doc raw"""
-    energy_flux(iter::VortexFilamentSolver, Nk::Integer; quad = nothing) -> (ks, fluxes)
-    energy_flux(iter::VortexFilamentSolver, ks::AbstractVector; quad = nothing) -> (ks, fluxes)
+    energy_flux(iter::VortexFilamentSolver, Nk::Integer; quad = iter.prob.p.quad) -> (ks, fluxes)
+    energy_flux(iter::VortexFilamentSolver, ks::AbstractVector; quad = iter.prob.p.quad) -> (ks, fluxes)
 
 Compute the energy "flux" across scales due to various velocity terms.
 
@@ -147,7 +147,7 @@ end
 function energy_flux(
         cache::LongRangeCache, fs, velocities::NamedTuple,
         ks::AbstractVector, params::ParamsBiotSavart;
-        quad = nothing, vs_buf = similar(first(velocities).field),
+        quad = params.quad, vs_buf = similar(first(velocities).field),
     )
     (; wavenumbers, state,) = BiotSavart.get_longrange_field_fourier(cache)
     @assert state.quantity == :velocity
@@ -187,8 +187,8 @@ end
 ## ========================================================================================== ##
 
 @doc raw"""
-    energy_transfer_matrix(iter::VortexFilamentSolver, Nk::Integer; quad = nothing) -> (ks, transfers)
-    energy_transfer_matrix(iter::VortexFilamentSolver, ks::AbstractVector; quad = nothing) -> (ks, transfers)
+    energy_transfer_matrix(iter::VortexFilamentSolver, Nk::Integer; quad = iter.prob.p.quad) -> (ks, transfers)
+    energy_transfer_matrix(iter::VortexFilamentSolver, ks::AbstractVector; quad = iter.prob.p.quad) -> (ks, transfers)
 
 Compute energy transfers between different Fourier shells.
 
@@ -264,7 +264,7 @@ end
 
 function energy_transfer_matrix(
         cache::LongRangeCache, fs::AbstractVector, vs::AbstractVector, ks::AbstractVector, params::ParamsBiotSavart;
-        quad = nothing,
+        quad = params.quad,
     )
     (; wavenumbers, state,) = BiotSavart.get_longrange_field_fourier(cache)
     @assert state.quantity == :velocity

--- a/src/Diagnostics/energy_injection.jl
+++ b/src/Diagnostics/energy_injection.jl
@@ -3,8 +3,8 @@ using LinearAlgebra: ⋅, ×
 export energy_injection_rate
 
 @doc raw"""
-    energy_injection_rate(iter::VortexFilamentSolver, [vL]; quad = nothing) -> Real
-    energy_injection_rate(fs, vL, vs, p::ParamsBiotSavart; quad = nothing) -> Real
+    energy_injection_rate(iter::VortexFilamentSolver, [vL]; quad = iter.prob.p.quad) -> Real
+    energy_injection_rate(fs, vL, vs, p::ParamsBiotSavart; quad = p.quad) -> Real
 
 Compute energy injection rate from current filament velocities.
 
@@ -72,7 +72,7 @@ function energy_injection_rate(
         vL::SetOfFilamentsData,
         vs::SetOfFilamentsData,
         p::ParamsBiotSavart{T};
-        quad = nothing,
+        quad = p.quad,
         nthreads = Threads.nthreads(),
     ) where {T <: AbstractFloat}
     @assert T === number_type(fs) === number_type(vL) === number_type(vs)
@@ -100,8 +100,7 @@ end
 
 function energy_injection_rate(
         f::AbstractFilament, vL, vs::SingleFilamentData, p::ParamsBiotSavart{T};
-        quad = nothing,
-        inds = eachindex(f),
+        quad = p.quad, inds = eachindex(f),
     ) where {T <: AbstractFloat}
     _energy_injection_rate(quad, f, vL, vs, inds, p)
 end

--- a/src/Diagnostics/helicity.jl
+++ b/src/Diagnostics/helicity.jl
@@ -3,9 +3,9 @@ export helicity
 using LinearAlgebra: ⋅
 
 @doc raw"""
-    helicity(iter::VortexFilamentSolver; quad = nothing) -> Real
+    helicity(iter::VortexFilamentSolver; quad = iter.prob.p.quad) -> Real
+    helicity(fs, vs, p::ParamsBiotSavart; quad = p.quad) -> Real
     helicity(fs, vs, Γ::Real; quad = nothing) -> Real
-    helicity(fs, vs, p::ParamsBiotSavart; quad = nothing) -> Real
 
 Compute helicity of a vortex configuration.
 
@@ -38,9 +38,13 @@ keyword argument.
 """
 function helicity end
 
-function helicity(fs::VectorOfFilaments, vs::SetOfFilamentsData, p; quad = nothing, nthreads = Threads.nthreads())  # p could be Γ::Real or a ParamsBiotSavart
+function helicity(fs::VectorOfFilaments, vs::SetOfFilamentsData, p::ParamsBiotSavart; quad = p.quad, nthreads = Threads.nthreads())
+    helicity(fs, vs, p.Γ; quad, nthreads)
+end
+
+function helicity(fs::VectorOfFilaments, vs::SetOfFilamentsData, Γ::Real; quad = nothing, nthreads = Threads.nthreads())
     maybe_parallelise_sum(fs, nthreads) do i, inds
-        helicity(fs[i], vs[i], p; quad, inds)
+        helicity(fs[i], vs[i], Γ; quad, inds)
     end
 end
 
@@ -49,7 +53,7 @@ function helicity(f::AbstractFilament, vs::SingleFilamentData, Γ::Real; quad = 
 end
 
 function helicity(f::AbstractFilament, vs::SingleFilamentData, p::ParamsBiotSavart; kws...)
-    helicity(f, vs, p.Γ; kws...)
+    helicity(f, vs, p.Γ; quad = p.quad, kws...)
 end
 
 function _helicity(::Nothing, f::AbstractFilament, vs::SingleFilamentData, inds, Γ::Real)

--- a/src/Diagnostics/stretching.jl
+++ b/src/Diagnostics/stretching.jl
@@ -1,7 +1,7 @@
 export stretching_rate
 
 @doc raw"""
-    stretching_rate(iter::VortexFilamentSolver; quad = nothing) -> Real
+    stretching_rate(iter::VortexFilamentSolver; quad = iter.prob.p.quad) -> Real
     stretching_rate(fs, vs; quad = nothing) -> Real
 
 Compute stretching rate of one or more vortices.
@@ -28,7 +28,7 @@ In the implementation, the last expression is the one used to compute the stretc
 
 ## Optional keyword arguments
 
-- `quad = nothing`: optional quadrature rule (e.g. `quad = GaussLegendre(4)`) used to
+- `quad`: optional quadrature rule (e.g. `quad = GaussLegendre(4)`) used to
   evaluate line integrals. If `nothing`, only values at nodes are used (cheaper).
 """
 function stretching_rate end

--- a/src/Diagnostics/vortex_impulse.jl
+++ b/src/Diagnostics/vortex_impulse.jl
@@ -1,7 +1,7 @@
 export vortex_impulse
 
 @doc raw"""
-    vortex_impulse(iter::VortexFilamentSolver; quad = nothing) -> Vec3
+    vortex_impulse(iter::VortexFilamentSolver; quad = iter.prob.p.quad) -> Vec3
     vortex_impulse(f; quad = nothing) -> Vec3
 
 Estimate normalised impulse of one or more vortex filaments.

--- a/src/Timestepping/diagnostics.jl
+++ b/src/Timestepping/diagnostics.jl
@@ -15,8 +15,9 @@ end
 function Diagnostics.kinetic_energy_from_streamfunction(iter::VortexFilamentSolver; kws...)
     _check_diagnostics(iter)
     (; ψs, fs, external_fields, t,) = iter
-    Ls = BiotSavart.periods(iter.prob.p)
-    E = Diagnostics.kinetic_energy_from_streamfunction(fs, ψs, iter.prob.p; kws...)
+    params = iter.prob.p
+    Ls = BiotSavart.periods(params)
+    E = Diagnostics.kinetic_energy_from_streamfunction(fs, ψs, params; quad = params.quad, kws...)
     # Add kinetic energy of external velocity field, if available.
     # Note that we only do this if we also included the streamfunction, since otherwise
     # we don't have enough information to estimate the total kinetic energy.
@@ -31,17 +32,18 @@ end
 function Diagnostics.kinetic_energy_nonperiodic(iter::VortexFilamentSolver; kws...)
     _check_diagnostics(iter)
     (; vs, fs,) = iter  # note: here we want vs (self-induced velocity) and not vL
-    Ls = BiotSavart.periods(iter.prob.p)
-    BiotSavart.domain_is_periodic(iter.prob.p) &&
+    params = iter.prob.p
+    Ls = BiotSavart.periods(params)
+    BiotSavart.domain_is_periodic(params) &&
         @warn(lazy"`kinetic_energy_nonperiodic` should only be called when working with non-periodic domains (got Ls = $Ls)")
-    Diagnostics.kinetic_energy_nonperiodic(fs, vs, iter.prob.p; kws...)
+    Diagnostics.kinetic_energy_nonperiodic(fs, vs, params; quad = params.quad, kws...)
 end
 
 function Diagnostics.energy_injection_rate(iter::VortexFilamentSolver, vL = iter.vL; kws...)
     _check_diagnostics(iter)
     (; vs, fs,) = iter
-    p = iter.prob.p
-    Diagnostics.energy_injection_rate(fs, vL, vs, p; kws...)
+    params = iter.prob.p
+    Diagnostics.energy_injection_rate(fs, vL, vs, params; quad = params.quad, kws...)
 end
 
 function Diagnostics.energy_flux(iter::VortexFilamentSolver, Nk_or_ks; kws...)
@@ -50,7 +52,7 @@ function Diagnostics.energy_flux(iter::VortexFilamentSolver, Nk_or_ks; kws...)
         vs = (field = iter.vs, sign = -1),
         vinf = (field = CurvatureVector(), sign = -1),
     )
-    p = iter.prob.p
+    params = iter.prob.p
     if hasproperty(iter, :vf)
         velocities = (; velocities..., vf = (field = iter.vf, sign = +1))
     end
@@ -58,14 +60,14 @@ function Diagnostics.energy_flux(iter::VortexFilamentSolver, Nk_or_ks; kws...)
         velocities = (; velocities..., vdiss = (field = iter.vdiss, sign = -1))
     end
     vs_buf = similar(iter.vs)
-    Diagnostics.energy_flux(iter, iter.fs, velocities, Nk_or_ks, p; vs_buf, kws...)
+    Diagnostics.energy_flux(iter, iter.fs, velocities, Nk_or_ks, params; quad = params.quad, vs_buf, kws...)
 end
 
 function Diagnostics.energy_transfer_matrix(iter::VortexFilamentSolver, Nk_or_ks; kws...)
     _check_diagnostics(iter)
     params = iter.prob.p
     Diagnostics.energy_transfer_matrix(
-        iter, iter.fs, iter.vs, Nk_or_ks, params; kws...
+        iter, iter.fs, iter.vs, Nk_or_ks, params; quad = params.quad, kws...
     )
 end
 

--- a/src/Timestepping/diagnostics.jl
+++ b/src/Timestepping/diagnostics.jl
@@ -76,23 +76,23 @@ end
 # difference really!).
 function Diagnostics.filament_length(iter::VortexFilamentSolver; kws...)
     _check_diagnostics(iter)
-    Diagnostics.filament_length(iter.fs; kws...)
+    Diagnostics.filament_length(iter.fs; quad = iter.prob.p.quad, kws...)
 end
 
 function Diagnostics.vortex_impulse(iter::VortexFilamentSolver; kws...)
     _check_diagnostics(iter)
-    Diagnostics.vortex_impulse(iter.fs; kws...)
+    Diagnostics.vortex_impulse(iter.fs; quad = iter.prob.p.quad, kws...)
 end
 
 function Diagnostics.helicity(iter::VortexFilamentSolver; kws...)
     _check_diagnostics(iter)
-    Diagnostics.helicity(iter.fs, iter.vL, iter.prob.p; kws...)
+    Diagnostics.helicity(iter.fs, iter.vL, iter.prob.p; quad = iter.prob.p.quad, kws...)
 end
 
 function Diagnostics.stretching_rate(iter::VortexFilamentSolver; kws...)
     _check_diagnostics(iter)
     (; fs, vL,) = iter
-    Diagnostics.stretching_rate(fs, vL; kws...)
+    Diagnostics.stretching_rate(fs, vL; quad = iter.prob.p.quad, kws...)
 end
 
 # This allows passing a VortexFilamentSolver to energy_spectrum / energy_spectrum!.

--- a/test/leapfrogging.jl
+++ b/test/leapfrogging.jl
@@ -86,7 +86,7 @@ function test_leapfrogging_rings(
 
     function callback(iter)
         local (; fs, vs, ψs, t, dt, nstep,) = iter
-        local quad = GaussLegendre(4)
+        local quad = iter.prob.p.quad
 
         if !can_compute_diagnostics(iter)
             @test_throws "ERROR: diagnostics cannot be computed at this timestep" Diagnostics.kinetic_energy(iter; quad)
@@ -102,9 +102,20 @@ function test_leapfrogging_rings(
         # end
 
         E = Diagnostics.kinetic_energy_from_streamfunction(iter; quad)
+        H = Diagnostics.helicity(iter; quad)  # should be zero...
         L = Diagnostics.filament_length(iter; quad)
         p⃗ = Diagnostics.vortex_impulse(iter; quad)
         dLdt = Diagnostics.stretching_rate(iter; quad)
+
+        if nstep == 1  # only test once
+            # Check that by default the quadrature in ParamsBiotSavart (i.e. iter.prob.p.quad) is used
+            @test E == Diagnostics.kinetic_energy_from_streamfunction(iter)
+            @test E == Diagnostics.kinetic_energy(iter)
+            @test H == Diagnostics.helicity(iter)
+            @test L == Diagnostics.filament_length(iter)
+            @test p⃗ == Diagnostics.vortex_impulse(iter)
+            @test dLdt == Diagnostics.stretching_rate(iter)
+        end
 
         # R²_all = @inferred sum(vortex_ring_squared_radius, fs)  # inference randomly fails on Julia 1.10-beta1...
         R²_all = 0.0

--- a/test/leapfrogging.jl
+++ b/test/leapfrogging.jl
@@ -109,12 +109,13 @@ function test_leapfrogging_rings(
 
         if nstep == 1  # only test once
             # Check that by default the quadrature in ParamsBiotSavart (i.e. iter.prob.p.quad) is used
-            @test E == Diagnostics.kinetic_energy_from_streamfunction(iter)
-            @test E == Diagnostics.kinetic_energy(iter)
-            @test H == Diagnostics.helicity(iter)
-            @test L == Diagnostics.filament_length(iter)
-            @test p⃗ == Diagnostics.vortex_impulse(iter)
-            @test dLdt == Diagnostics.stretching_rate(iter)
+            rtol = 10 * eps(eltype(E))  # tiny differences can be expected when multiple threads are used
+            @test E ≈ Diagnostics.kinetic_energy_from_streamfunction(iter) rtol=rtol
+            @test E ≈ Diagnostics.kinetic_energy(iter) rtol=rtol
+            @test H ≈ Diagnostics.helicity(iter) rtol=rtol
+            @test L ≈ Diagnostics.filament_length(iter) rtol=rtol
+            @test p⃗ ≈ Diagnostics.vortex_impulse(iter) rtol=rtol
+            @test dLdt ≈ Diagnostics.stretching_rate(iter) rtol=rtol
         end
 
         # R²_all = @inferred sum(vortex_ring_squared_radius, fs)  # inference randomly fails on Julia 1.10-beta1...

--- a/test/leapfrogging.jl
+++ b/test/leapfrogging.jl
@@ -109,7 +109,7 @@ function test_leapfrogging_rings(
 
         if nstep == 1  # only test once
             # Check that by default the quadrature in ParamsBiotSavart (i.e. iter.prob.p.quad) is used
-            rtol = 10 * eps(eltype(E))  # tiny differences can be expected when multiple threads are used
+            rtol = 100 * eps(eltype(E))  # tiny differences can be expected when multiple threads are used
             @test E ≈ Diagnostics.kinetic_energy_from_streamfunction(iter) rtol=rtol
             @test E ≈ Diagnostics.kinetic_energy(iter) rtol=rtol
             @test H ≈ Diagnostics.helicity(iter) rtol=rtol


### PR DESCRIPTION
This changes the default quadrature from `nothing` to `iter.prob.p.quad` (or `params.quad`) when computing diagnostics requiring line integrals.